### PR TITLE
Add support for mfa caching

### DIFF
--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -8,6 +8,7 @@ import functools
 import click
 from botocore.config import Config as BotocoreConfig
 from botocore.session import Session
+from botocore.credentials import JSONFileCache
 from typing import Any, Optional, Dict, MutableMapping  # noqa
 
 from chalice import __version__ as chalice_version
@@ -41,6 +42,10 @@ def create_botocore_session(profile=None, debug=False,
                             max_retries=None):
     # type: (OptStr, bool, OptInt, OptInt, OptInt) -> Session
     s = Session(profile=profile)
+    s.get_component('credential_provider').get_provider('assume-role').cache \
+        = JSONFileCache(
+            os.path.join(os.path.expanduser('~'),'.aws/cli/cache')
+        )
     _add_chalice_user_agent(s)
     if debug:
         _inject_large_request_body_filter()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds support for using botocore's CLI cache to store MFA sessions.  After entering an MFA token, users will not be prompted again until the expiration has past (typically 60 minutes)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
